### PR TITLE
Support daemonizing of delayed_job_celluloid

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ Currently the gem does not support daemonization of the main process because I h
 	    ActiveRecord::Base.establish_connection
 	end
 
-If you are interested in adding daemonization to the gem itself, feel free to fork it and submit a pull request.
+## Daemonization
+
+    script/delayed_job_celluloid --daemonize --log /path/to/my/logfile.log start
+    script/delayed_job_celluloid --daemonize --log /path/to/my/logfile.log stop
 
 ## Contributing
 

--- a/lib/delayed_job_celluloid/command.rb
+++ b/lib/delayed_job_celluloid/command.rb
@@ -2,6 +2,7 @@ $stdout.sync = true
 
 require 'optparse'
 require 'celluloid'
+require 'daemons'
 
 module DelayedJobCelluloid
   

--- a/lib/delayed_job_celluloid/command.rb
+++ b/lib/delayed_job_celluloid/command.rb
@@ -21,7 +21,7 @@ module DelayedJobCelluloid
 
     def daemonize
 
-      Daemons.run_proc('delayed_job_celluloid', :dir => @options[:pid_dir], :dir_mode => :normal, :monitor => @monitor,
+      Daemons.run_proc(@options[:worker_name], :dir => @options[:pid_dir], :dir_mode => :normal, :monitor => @monitor,
                                                                                             :ARGV => @args) do |*_args|
         Celluloid.register_shutdown
         Celluloid.start
@@ -110,7 +110,8 @@ module DelayedJobCelluloid
       @options = {
         :quiet => true,
         :timeout => 8,
-        :log_file => 'celluloid.log'
+        :log_file => 'celluloid.log',
+        :worker_name => 'delayed_job_celluloid'
       }
 
       @worker_count = 2
@@ -133,6 +134,12 @@ module DelayedJobCelluloid
         end
         opts.on('-n', '--number_of_workers=workers', "Number of worker threads to start") do |worker_count|
           @worker_count = worker_count.to_i rescue 1
+        end
+        opts.on('--pid-dir=DIR', 'Specifies an alternate directory in which to store the process ids.') do |dir|
+          @options[:pid_dir] = dir
+        end
+        opts.on('--worker-name=NAME', 'Specifies an alternate worker name') do |name|
+          @options[:worker_name] = name
         end
         opts.on('--sleep-delay N', "Amount of time to sleep when no jobs are found") do |n|
           @options[:sleep_delay] = n.to_i


### PR DESCRIPTION
This is an amazing find for me! We have been struggling with DJ memory usage for months, trying everything, including stripping out Rails components in the DJ load sequence. We hope to get this working with 10 threads, so our memory usage will be a lot less than 2Gb, so we can replace our existing background job script!

Unfortunately, I could not get Minitest to work with the existing tests... even after switching to `Klass < Minitest::Test`. Which version of minitest are you using? Might have to leave this for another day.

Cheers,
Nigel
